### PR TITLE
Feat: overlay sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- N/A
+- Sidebar now opens as an overlay without shifting page content
 
 ### Fixed
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -244,15 +244,6 @@ const Sidebar = React.forwardRef<
       >
         <div
           className={cn(
-            "duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear",
-            "group-data-[collapsible=icon]:w-[--sidebar-width-icon]", // Collapses to icon width
-             // variant === "floating" || variant === "inset"
-             //  ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
-             //  : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
-          )}
-        />
-        <div
-          className={cn(
             "duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex",
             side === "left" ? "left-0" : "right-0",
             variant === "floating" || variant === "inset"


### PR DESCRIPTION
## What changed & why
- make sidebar overlay page content rather than reserving width
- document overlay behavior in changelog

## Testing done
- `npm ci`
- `npm run lint` *(fails: ESLint missing)*
- `npm test` *(fails: missing @babel/preset-env)*
- `npm run typecheck`
- `npm run build` *(fails: blocked font downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684cecffb82083239f296f8ebda7b1d1