### PR TITLE
Fix: align schedule pump cards with kanban

### DIFF
--- a/src/components/schedule/SchedulePumpCard.tsx
+++ b/src/components/schedule/SchedulePumpCard.tsx
@@ -73,9 +73,9 @@ export const SchedulePumpCard = React.memo(function SchedulePumpCard({
   const priorityClass = () => {
     switch (pump.priority) {
       case "high":
-        return "border-orange-500";
+        return "priority-high";
       case "urgent":
-        return "border-red-600";
+        return "priority-urgent";
       default:
         return "";
     }
@@ -88,7 +88,7 @@ export const SchedulePumpCard = React.memo(function SchedulePumpCard({
       onDragEnd={handleDragEndInternal}
       onClick={handleCardClick}
       className={cn(
-        "glass-card group cursor-grab active:cursor-grabbing select-none w-[16.75rem]",
+        "glass-card group cursor-grab active:cursor-grabbing select-none w-full",
         priorityClass(),
         isSelected && "selected",
       )}


### PR DESCRIPTION
## What changed & why
- schedule pump cards now reuse `priority-high`/`priority-urgent` classes
- removed fixed width so cards match kanban size

## Testing done
- `npm run lint`
- `npm test`
- `npm run build` *(fails: fonts.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cee64acb88323b9ee723df37d4d13