### PR TITLE
Feat: extend pump KPI types

### DIFF
--- a/src/components/schedule/KpiDeck.tsx
+++ b/src/components/schedule/KpiDeck.tsx
@@ -12,13 +12,14 @@ interface KpiDeckProps {
 
 const KpiDeckComponent: React.FC<KpiDeckProps> = ({ snapshot }) => {
   // Card 1: Unscheduled
-  const unscheduledValue = `${snapshot.unscheduledCount} of ${snapshot.totalOnOrder}`;
+  const unscheduledValue = `${snapshot.remainingBuildUnscheduled}d`;
 
   // Card 2: Remaining Work (stacked rows)
   const remainingRows: KpiSubRow[] = [
-    { label: "Unscheduled", value: snapshot.unscheduledCount },
-    { label: "Scheduled", value: snapshot.scheduledCount },
-    { label: "In Process", value: snapshot.inProcessCount },
+    { label: "Unscheduled", value: snapshot.remainingBuildUnscheduled },
+    { label: "Scheduled", value: snapshot.remainingBuildScheduled },
+    { label: "In Process", value: snapshot.remainingBuildInProcess },
+    { label: "Queue", value: snapshot.remainingBuildQueue },
   ];
 
   // Card 3: Capacity

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,12 @@ export interface Pump {
   priority?: PriorityLevel;
   estimatedBuildTimeDays?: number; // Editable estimate for build time
   actualDurationDays?: number; // Actual time taken, to be populated later
+  /** Status of the pump in the overall build lifecycle */
+  status?: PumpStatus;
+  /** Total estimated build time (days) for analytics */
+  buildTimeDays?: number;
+  /** Remaining build time (days) based on schedule */
+  remainingBuildTimeDays?: number;
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string
 }
@@ -62,6 +68,7 @@ export type PumpStatus =
   | 'unscheduled'
   | 'scheduled'
   | 'in_process'
+  | 'queue'
   | 'completed'
   | 'shipped';
 
@@ -69,11 +76,16 @@ export type PumpStatus =
  * KpiSnapshot: Structure of KPI data returned from /api/kpis.
  */
 export interface KpiSnapshot {
-  unscheduledCount: number;
-  totalOnOrder: number;
-  scheduledCount: number;
-  inProcessCount: number;
-  utilizationPct?: number | null;
+  /** Remaining build days for unscheduled pumps */
+  remainingBuildUnscheduled: number;
+  /** Remaining build days for scheduled pumps */
+  remainingBuildScheduled: number;
+  /** Remaining build days for pumps currently in process */
+  remainingBuildInProcess: number;
+  /** Sum of remaining build days in the queue */
+  remainingBuildQueue: number;
+  /** Optional utilization percentage for capacity metrics */
+  utilizationPct?: number;
 }
 
 // New type for Activity Log Entries


### PR DESCRIPTION
## What changed & why
- expanded `Pump` with lifecycle and build tracking fields
- added `queue` state to `PumpStatus`
- replaced `KpiSnapshot` metrics with remaining build fields
- updated `KpiDeck` component to use new KPI metrics

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` and `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f15490508323992c55ad02925404