### PR TITLE
Fix: update KPI card icon typing and memo

### DIFF
--- a/src/components/schedule/KpiCard.tsx
+++ b/src/components/schedule/KpiCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { LucideIcon } from 'lucide-react';
 
 export interface KpiSubRow {
   label: string;
@@ -7,7 +8,7 @@ export interface KpiSubRow {
 
 export interface KpiCardProps {
   id: string;
-  icon: React.ReactNode;
+  icon: LucideIcon;
   label: string;
   value: string | number;
   subRows?: KpiSubRow[];
@@ -21,12 +22,14 @@ const KpiCardComponent: React.FC<KpiCardProps> = ({
   subRows,
 }) => (
   <div
-    className="w-48 rounded-lg bg-glass/30 backdrop-blur p-4 shadow-lg border border-glass-border flex flex-col gap-2"
+    className="w-48 rounded-lg bg-glass/30 backdrop-blur p-4 shadow-md border border-glass-border flex flex-col gap-2"
     id={id}
     data-testid={`kpi-card-${id}`}
   >
     <div className="flex items-center gap-2">
-      <span className="text-2xl text-glass-accent-purple">{icon}</span>
+      <span className="text-2xl text-glass-accent-purple">
+        {React.createElement(icon, { className: 'h-5 w-5' })}
+      </span>
       <span className="text-base font-medium text-glass-text-primary">{label}</span>
     </div>
     <div className="text-2xl font-semibold text-glass-text-primary">{value}</div>
@@ -48,10 +51,35 @@ const KpiCardComponent: React.FC<KpiCardProps> = ({
 
 export const KpiCard = React.memo(
   KpiCardComponent,
-  (prev, next) =>
-    prev.id === next.id &&
-    prev.label === next.label &&
-    prev.value === next.value &&
-    prev.icon === next.icon &&
-    JSON.stringify(prev.subRows) === JSON.stringify(next.subRows)
+  (prev, next) => {
+    if (
+      prev.id !== next.id ||
+      prev.label !== next.label ||
+      prev.value !== next.value ||
+      prev.icon !== next.icon
+    ) {
+      return false;
+    }
+
+    if (prev.subRows === next.subRows) {
+      return true;
+    }
+
+    if (!prev.subRows || !next.subRows) {
+      return false;
+    }
+
+    if (prev.subRows.length !== next.subRows.length) {
+      return false;
+    }
+
+    for (let i = 0; i < prev.subRows.length; i++) {
+      const a = prev.subRows[i];
+      const b = next.subRows[i];
+      if (a.label !== b.label || a.value !== b.value) {
+        return false;
+      }
+    }
+    return true;
+  }
 );

--- a/src/components/schedule/KpiDeck.tsx
+++ b/src/components/schedule/KpiDeck.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import useSWR from "swr";
+import { Package, Layers, Zap } from 'lucide-react';
 import { KpiCard, KpiSubRow } from "./KpiCard";
 import type { KpiSnapshot } from "@/types";
 
@@ -31,20 +32,20 @@ const KpiDeckComponent: React.FC<KpiDeckProps> = ({ snapshot }) => {
     <div className="flex gap-6">
       <KpiCard
         id="unscheduled"
-        icon={<span role="img" aria-label="Unscheduled">📦</span>}
+        icon={Package}
         label="Unscheduled"
         value={unscheduledValue}
       />
       <KpiCard
         id="remaining"
-        icon={<span role="img" aria-label="Remaining Work">🗂️</span>}
+        icon={Layers}
         label="Remaining Work"
         value=""
         subRows={remainingRows}
       />
       <KpiCard
         id="capacity"
-        icon={<span role="img" aria-label="Capacity">⚡</span>}
+        icon={Zap}
         label="Capacity"
         value={capacityValue}
       />


### PR DESCRIPTION
## What changed & why
- restrict `KpiCard` icon prop to `LucideIcon`
- adjust memo comparison to shallow compare `subRows`
- switched card shadow to `shadow-md`
- updated `KpiDeck` icons to use Lucide icons

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f15b4e6883239ef2f64e7e3247c0