### PR TITLE
Fix: add client directive to KpiDeck

### DIFF
--- a/src/components/schedule/KpiDeck.tsx
+++ b/src/components/schedule/KpiDeck.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import useSWR from "swr";
 import { KpiCard, KpiSubRow } from "./KpiCard";


### PR DESCRIPTION
## What changed & why
- mark `KpiDeck` as a client component to enable client-side hooks

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `npm run type-check` *(fails: missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f65fa13c83238cc92ad70270d1f8