### PR TITLE
Fix: update remaining work KPIs

### DIFF
--- a/src/components/schedule/KpiDeck.tsx
+++ b/src/components/schedule/KpiDeck.tsx
@@ -15,10 +15,20 @@ const KpiDeckComponent: React.FC<KpiDeckProps> = ({ snapshot }) => {
   const unscheduledValue = `${snapshot.unscheduledCount} of ${snapshot.totalOnOrder}`;
 
   // Card 2: Remaining Work (stacked rows)
+  // Values represent days remaining for each category
   const remainingRows: KpiSubRow[] = [
-    { label: "Unscheduled", value: snapshot.unscheduledCount },
-    { label: "Scheduled", value: snapshot.scheduledCount },
-    { label: "In Process", value: snapshot.inProcessCount },
+    {
+      label: "Unscheduled",
+      value: `${snapshot.remainingBuildUnscheduled} d`,
+    },
+    {
+      label: "Scheduled",
+      value: `${snapshot.remainingBuildScheduled} d`,
+    },
+    {
+      label: "In Process",
+      value: `${snapshot.remainingBuildInProcess} d`,
+    },
   ];
 
   // Card 3: Capacity

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,6 +73,10 @@ export interface KpiSnapshot {
   totalOnOrder: number;
   scheduledCount: number;
   inProcessCount: number;
+  remainingBuildUnscheduled: number;
+  remainingBuildScheduled: number;
+  remainingBuildInProcess: number;
+  remainingBuildQueue?: number;
   utilizationPct?: number | null;
 }
 


### PR DESCRIPTION
## What changed & why
- show remaining build durations using the new fields
- expose the new remaining build fields in `KpiSnapshot`

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `npm run type-check` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f6620ba083238d2f031cbd56c0a7