### PR TITLE
Feat: update KPI types

### DIFF
--- a/src/components/schedule/KpiDeck.tsx
+++ b/src/components/schedule/KpiDeck.tsx
@@ -16,9 +16,10 @@ const KpiDeckComponent: React.FC<KpiDeckProps> = ({ snapshot }) => {
 
   // Card 2: Remaining Work (stacked rows)
   const remainingRows: KpiSubRow[] = [
-    { label: "Unscheduled", value: snapshot.unscheduledCount },
-    { label: "Scheduled", value: snapshot.scheduledCount },
-    { label: "In Process", value: snapshot.inProcessCount },
+    { label: "Unscheduled", value: snapshot.remainingBuildUnscheduled },
+    { label: "Scheduled", value: snapshot.remainingBuildScheduled },
+    { label: "Queue", value: snapshot.remainingBuildQueue },
+    { label: "In Process", value: snapshot.remainingBuildInProcess },
   ];
 
   // Card 3: Capacity

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,19 +61,24 @@ export interface Filters {
 export type PumpStatus =
   | 'unscheduled'
   | 'scheduled'
-  | 'in_process'
-  | 'completed'
+  | 'queue'
+  | 'fabrication'
+  | 'powderCoat'
+  | 'assembly'
+  | 'testing'
   | 'shipped';
 
 /**
  * KpiSnapshot: Structure of KPI data returned from /api/kpis.
  */
 export interface KpiSnapshot {
-  unscheduledCount: number;
   totalOnOrder: number;
-  scheduledCount: number;
-  inProcessCount: number;
-  utilizationPct?: number | null;
+  unscheduledCount: number;
+  remainingBuildUnscheduled: number;
+  remainingBuildScheduled: number;
+  remainingBuildInProcess: number;
+  remainingBuildQueue: number;
+  utilizationPct?: number;
 }
 
 // New type for Activity Log Entries


### PR DESCRIPTION
## What changed & why
- expanded `PumpStatus` union with v2 statuses
- refactored `KpiSnapshot` structure for new build metrics
- updated `KpiDeck` component to display new KPI fields

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `npm run typecheck` *(script alias)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851a4f81a2c8323ba8293c04f133d36