### PR TITLE
Fix: disable Genkit tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Sidebar now opens as an overlay without shifting page content
+- Disabled OpenTelemetry tracing during Next.js builds to avoid missing exporter errors
 
 ### Fixed
 

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,3 +1,8 @@
+// Disable OpenTelemetry tracing to avoid build-time errors when the
+// required exporters are not present. This must be set before importing
+// Genkit, otherwise tracing initialization will run automatically.
+process.env.OTEL_SDK_DISABLED ??= 'true';
+
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
 


### PR DESCRIPTION
## What changed & why
- set `OTEL_SDK_DISABLED` before loading Genkit to skip tracing setup
- noted this behavior in `CHANGELOG.md`

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `npm run type-check` *(fails: missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f66d8a0c83239cca765be1d034e0