### PR TITLE
Fix: correct VSCode settings JSON

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "IDX.aI.enableInlineCompletion": true,
-    "IDX.aI.enableCodebaseIndexing": true
-    "npm.packageManager": "pnpm@9"
-  }
+  "IDX.aI.enableInlineCompletion": true,
+  "IDX.aI.enableCodebaseIndexing": true,
+  "npm.packageManager": "pnpm@9"
+}
   


### PR DESCRIPTION
## What changed & why
- Fixed `.vscode/settings.json` to have valid JSON with trailing comma

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853218e90c48323abbfddec1adade77