### PR TITLE
Feat: add pump API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Initial project structure and documentation stubs.
 - MIT license and package metadata.
+- API routes for pumps and scheduling
 
 ### Changed
 

--- a/__mocks__/pumpService.ts
+++ b/__mocks__/pumpService.ts
@@ -1,0 +1,21 @@
+import type { Pump } from "@/types";
+
+export const samplePumps: Pump[] = [
+  {
+    id: "pump-1",
+    model: "Model A",
+    customer: "Customer",
+    poNumber: "PO-1",
+    currentStage: "open-jobs",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+];
+
+export const getAllPumps = jest.fn(async () => samplePumps);
+
+export const addPumpWithActivityLog = jest.fn();
+export const updatePumpWithActivityLog = jest.fn();
+export const movePumpStageWithActivityLog = jest.fn();
+export const getPumpActivityLog = jest.fn();
+export const addNoteToPumpWithActivityLog = jest.fn();

--- a/__mocks__/scheduleService.ts
+++ b/__mocks__/scheduleService.ts
@@ -1,11 +1,12 @@
 import type { CalendarBlock } from "@/types";
+import { randomUUID } from "crypto";
 
 export const blocks: CalendarBlock[] = [];
 
 export const createOrUpdateCalendarBlock = jest.fn(
   async (_pumpId: string, start: string, end: string) => {
     const block: CalendarBlock = {
-      id: "mock-block",
+      id: randomUUID(),
       pumpId: _pumpId,
       start,
       end,

--- a/__mocks__/scheduleService.ts
+++ b/__mocks__/scheduleService.ts
@@ -1,0 +1,22 @@
+import type { CalendarBlock } from "@/types";
+
+export const blocks: CalendarBlock[] = [];
+
+export const createOrUpdateCalendarBlock = jest.fn(
+  async (_pumpId: string, start: string, end: string) => {
+    const block: CalendarBlock = {
+      id: "mock-block",
+      pumpId: _pumpId,
+      start,
+      end,
+    };
+    blocks.push(block);
+    return block;
+  },
+);
+
+export const __reset = () => {
+  blocks.length = 0;
+};
+
+export const getBlocks = jest.fn(() => blocks);

--- a/src/app/api/pumps/[id]/schedule/route.ts
+++ b/src/app/api/pumps/[id]/schedule/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createOrUpdateCalendarBlock } from "@/services/scheduleService";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const { start, end } = await request.json();
+    const block = await createOrUpdateCalendarBlock(params.id, start, end);
+    return NextResponse.json(block, { status: 200 });
+  } catch (err) {
+    if ((err as Error).message === "CONFLICT") {
+      return NextResponse.json({ error: "Schedule conflict" }, { status: 409 });
+    }
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/src/app/api/pumps/[id]/schedule/route.ts
+++ b/src/app/api/pumps/[id]/schedule/route.ts
@@ -1,17 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
+interface HandlerContext {
+  params?: Promise<Record<string, string | string[] | undefined>>;
+}
 import { createOrUpdateCalendarBlock } from "@/services/scheduleService";
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
-) {
+  { params }: HandlerContext,
+): Promise<NextResponse> {
   try {
     const { start, end } = await request.json();
-    const block = await createOrUpdateCalendarBlock(params.id, start, end);
+    if (typeof start !== "string" || typeof end !== "string") {
+      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+    }
+    const resolvedParams = (await params) ?? {};
+    const id = Array.isArray(resolvedParams.id)
+      ? resolvedParams.id[0]
+      : resolvedParams.id;
+    if (typeof id !== "string") {
+      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+    }
+    const block = await createOrUpdateCalendarBlock(id, start, end);
     return NextResponse.json(block, { status: 200 });
   } catch (err) {
-    if ((err as Error).message === "CONFLICT") {
+    const msg = (err as Error).message;
+    if (msg === "CONFLICT") {
       return NextResponse.json({ error: "Schedule conflict" }, { status: 409 });
+    }
+    if (msg === "INVALID_DATES") {
+      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
     }
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }

--- a/src/app/api/pumps/route.ts
+++ b/src/app/api/pumps/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getAllPumps } from "@/services/pumpService";
+
+export async function GET() {
+  const pumps = await getAllPumps();
+  return NextResponse.json(pumps);
+}

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -1,4 +1,5 @@
 import { CalendarBlock } from "@/types";
+import { randomUUID } from "crypto";
 
 // In-memory store for demo/testing
 const blocks: CalendarBlock[] = [];
@@ -15,6 +16,14 @@ export async function createOrUpdateCalendarBlock(
   const startDate = new Date(start);
   const endDate = new Date(end);
 
+  if (
+    isNaN(startDate.getTime()) ||
+    isNaN(endDate.getTime()) ||
+    startDate >= endDate
+  ) {
+    throw new Error("INVALID_DATES");
+  }
+
   // Check conflicts with existing blocks for this pump
   for (const block of blocks) {
     if (
@@ -25,14 +34,13 @@ export async function createOrUpdateCalendarBlock(
     }
   }
 
-  let block = blocks.find((b) => b.pumpId === pumpId);
-  if (block) {
-    block.start = start;
-    block.end = end;
-  } else {
-    block = { id: crypto.randomUUID(), pumpId, start, end };
-    blocks.push(block);
-  }
+  const block: CalendarBlock = {
+    id: randomUUID(),
+    pumpId,
+    start,
+    end,
+  };
+  blocks.push(block);
   return block;
 }
 

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -1,0 +1,45 @@
+import { CalendarBlock } from "@/types";
+
+// In-memory store for demo/testing
+const blocks: CalendarBlock[] = [];
+
+function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) {
+  return aStart < bEnd && aEnd > bStart;
+}
+
+export async function createOrUpdateCalendarBlock(
+  pumpId: string,
+  start: string,
+  end: string,
+): Promise<CalendarBlock> {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+
+  // Check conflicts with existing blocks for this pump
+  for (const block of blocks) {
+    if (
+      block.pumpId === pumpId &&
+      overlaps(startDate, endDate, new Date(block.start), new Date(block.end))
+    ) {
+      throw new Error("CONFLICT");
+    }
+  }
+
+  let block = blocks.find((b) => b.pumpId === pumpId);
+  if (block) {
+    block.start = start;
+    block.end = end;
+  } else {
+    block = { id: crypto.randomUUID(), pumpId, start, end };
+    blocks.push(block);
+  }
+  return block;
+}
+
+export function __reset() {
+  blocks.length = 0;
+}
+
+export function getBlocks() {
+  return blocks;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,16 +1,15 @@
-
-import type { LucideIcon } from 'lucide-react';
-import type { PRIORITY_LEVELS } from '@/lib/constants';
+import type { LucideIcon } from "lucide-react";
+import type { PRIORITY_LEVELS } from "@/lib/constants";
 
 export type StageId =
-  | 'open-jobs'
-  | 'fabrication'
-  | 'assembly'
-  | 'testing'
-  | 'powder-coat'
-  | 'shipped';
+  | "open-jobs"
+  | "fabrication"
+  | "assembly"
+  | "testing"
+  | "powder-coat"
+  | "shipped";
 
-export type PriorityLevel = typeof PRIORITY_LEVELS[number]['value'];
+export type PriorityLevel = (typeof PRIORITY_LEVELS)[number]["value"];
 
 export interface Pump {
   id: string; // Unique identifier for the pump
@@ -43,7 +42,7 @@ export interface Stage {
   icon: LucideIcon;
 }
 
-export type ViewMode = 'default' | 'condensed';
+export type ViewMode = "default" | "condensed";
 
 export interface Filters {
   serialNumber?: string[];
@@ -59,11 +58,11 @@ export interface Filters {
  * Adjust as needed to match backend/API.
  */
 export type PumpStatus =
-  | 'unscheduled'
-  | 'scheduled'
-  | 'in_process'
-  | 'completed'
-  | 'shipped';
+  | "unscheduled"
+  | "scheduled"
+  | "in_process"
+  | "completed"
+  | "shipped";
 
 /**
  * KpiSnapshot: Structure of KPI data returned from /api/kpis.
@@ -78,15 +77,15 @@ export interface KpiSnapshot {
 
 // New type for Activity Log Entries
 export type ActivityLogType =
-  | 'PUMP_CREATED'
-  | 'PUMP_UPDATED'
-  | 'STAGE_MOVED'
-  | 'NOTE_ADDED'
-  | 'NOTE_UPDATED'
-  | 'PRIORITY_CHANGED'
-  | 'DETAILS_EDITED' // Generic for other field changes
-  | 'PUMP_ARCHIVED'
-  | 'PUMP_DELETED';
+  | "PUMP_CREATED"
+  | "PUMP_UPDATED"
+  | "STAGE_MOVED"
+  | "NOTE_ADDED"
+  | "NOTE_UPDATED"
+  | "PRIORITY_CHANGED"
+  | "DETAILS_EDITED" // Generic for other field changes
+  | "PUMP_ARCHIVED"
+  | "PUMP_DELETED";
 
 export interface ActivityLogEntry {
   id: string; // Unique ID for the log entry
@@ -96,4 +95,11 @@ export interface ActivityLogEntry {
   description: string; // Human-readable description of the change
   details?: Record<string, any>; // Optional field for specific changed values, e.g., { fromStage: 'A', toStage: 'B', field: 'serialNumber', oldValue: 'X', newValue: 'Y' }
   userId?: string; // Optional: ID of the user who performed the action (for future use with authentication)
+}
+
+export interface CalendarBlock {
+  id: string;
+  pumpId: string;
+  start: string;
+  end: string;
 }


### PR DESCRIPTION
## What changed & why
- added `GET /api/pumps` endpoint
- implemented schedule POST endpoint for pumps with conflict detection
- created schedule service with in‑memory blocks
- added jest mocks for schedule and pump services
- updated changelog

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` and `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685458847c6483239e3d3386ca60e8a9