### PR TITLE
Docs: add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+FIRESTORE_EMULATOR_HOST=localhost:8080
+GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccount.json

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Initial project structure and documentation stubs.
 - MIT license and package metadata.
+- `.env.example` with Firestore emulator and service account placeholders.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To get started, take a look at `src/app/page.tsx`.
 - Start: `pnpm dev`
 - Check code: `pnpm lint && pnpm test && pnpm typecheck`
 - Add environment variables: copy `.env.example` to `.env.local` and fill in
+  - `FIRESTORE_EMULATOR_HOST=localhost:8080`
+  - `GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccount.json`
 
 ## Coding & Branching
 

--- a/contributing.md
+++ b/contributing.md
@@ -16,6 +16,8 @@ Thank you for contributing to PumpTrack! This guide will help you set up your de
    ```
 3. **Copy and edit environment variables:**
    - Copy `.env.example` to `.env.local` and fill in required values.
+     - `FIRESTORE_EMULATOR_HOST=localhost:8080`
+     - `GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccount.json`
 4. **Run the dev server:**
    ```bash
    pnpm dev


### PR DESCRIPTION
## Summary
- add `.env.example` with Firestore emulator and credentials placeholders
- document copying the example to `.env.local`
- allow tracking the example in `.gitignore`
- note the addition in CHANGELOG

## Testing
- `pnpm lint && pnpm test && pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685f83cc40e88323bf53b2cb341198cb