### PR TITLE
Docs: improve onboarding info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,27 @@ To get started, take a look at `src/app/page.tsx`.
 
 - Node version: 20 (see .nvmrc, Nix config)
 - Dependency manager: pnpm (activate via corepack)
-- Install: `pnpm install && corepack pnpm approve-builds`
-- Start: `pnpm dev`
-- Check code: `pnpm lint && pnpm test && pnpm typecheck`
-- Add environment variables: copy `.env.example` to `.env.local` and fill in
-  - `FIRESTORE_EMULATOR_HOST=localhost:8080`
-  - `GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccount.json`
+
+1. **Install dependencies and approve builds**
+   ```bash
+   pnpm install
+   corepack pnpm approve-builds
+   ```
+2. **Copy environment variables**
+   ```bash
+   cp .env.example .env.local
+   # then fill in required values
+   ```
+   - `FIRESTORE_EMULATOR_HOST=localhost:8080`
+   - `GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccount.json`
+3. **Start the dev server**
+   ```bash
+   pnpm dev
+   ```
+4. **Check code**
+   ```bash
+   pnpm lint && pnpm test && pnpm typecheck
+   ```
 
 ## Coding & Branching
 
@@ -27,3 +42,4 @@ To get started, take a look at `src/app/page.tsx`.
 
 - [PumpTrack MVP / Demo-Ready Checklist] is your task list and the only onboarding you need
 - Remove/ignore all legacy/manual scripts/instructions
+- See [docs/architecture-notes.md](docs/architecture-notes.md) for project structure

--- a/contributing.md
+++ b/contributing.md
@@ -22,7 +22,7 @@ Thank you for contributing to PumpTrack! This guide will help you set up your de
    ```bash
    pnpm dev
    ```
-5. **Run lint/typecheck/tests before every commit:**
+5. **Run lint, tests, and type-check before every commit:**
    ```bash
    pnpm lint && pnpm test && pnpm typecheck
    ```
@@ -47,7 +47,7 @@ Thank you for contributing to PumpTrack! This guide will help you set up your de
 
 ## 🛠️ React/Next.js Conventions
 
-- **All components in ****\`\`**** use React Server Components (RSC) by default**
+- All components in `src/app` use React Server Components (RSC) by default
 - Use `"use client"` at the top of files that require interactivity (hooks, event handlers, refs)
 - Only add client dependencies to files that must run on the client
 
@@ -58,6 +58,7 @@ Thank you for contributing to PumpTrack! This guide will help you set up your de
 - Keep AGENTS.md and README.md in sync with MVP Checklist
 - Archive any outdated scripts, docs, or instructions to `/legacy` (do not delete outright)
 - When adding a new ENV variable, update `.env.example` too
+- Review [docs/architecture-notes.md](docs/architecture-notes.md) for project structure
 
 ---
 


### PR DESCRIPTION
## What changed & why
- clarified setup steps in README to copy `.env.example`, approve builds, and run dev server
- fixed markdown fencing and added architecture notes link
- improved CONTRIBUTING quickstart wording and link to architecture docs

## Testing done
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685f888dfc648323a45b1461d97a58be