### PR TITLE
fix: calendar block placement

### DIFF
--- a/src/components/calendar/CalendarBlock.tsx
+++ b/src/components/calendar/CalendarBlock.tsx
@@ -38,7 +38,12 @@ export const CalendarBlock: React.FC<CalendarBlockProps> = ({
         "text-xs rounded-sm p-1 border shadow-sm overflow-hidden cursor-grab active:cursor-grabbing",
         colorClass,
       )}
-      style={{ opacity: isDragging ? 0.5 : 1, gridColumn: `span ${duration}`, ...style }}
+      style={{
+        opacity: isDragging ? 0.5 : 1,
+        // span across duration without overriding start position
+        gridColumnEnd: `span ${Math.ceil(duration)}`,
+        ...style,
+      }}
     >
       {pump.model}
     </div>


### PR DESCRIPTION
## Summary
- allow calendar blocks to span without overriding the start column

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68608f12be608323bd46d990f0d6833e